### PR TITLE
Support flush on sinks:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frib_datasource"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 description = "Data sources for FRIB ringitem data"
 license = "LGPL-3.0-or-later"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,10 @@ pub trait DataSink {
     /// Close the sink.  After this is done, all write's will fail.
     /// 
     fn close(&mut self);
+    ///
+    /// If supported by the sink, flush any buffered data to the sink.
+    /// 
+    fn flush(&mut self) {}
 }
 
 

--- a/src/offline.rs
+++ b/src/offline.rs
@@ -172,6 +172,7 @@ impl DataSource for FileDataSource {
     fn close(&mut self) {
         self.source = None;
     }
+    
 }
 
 /// Data sink.  THis can be either a file or stdout.
@@ -235,5 +236,10 @@ impl DataSink for FileDataSink {
     }
     fn close(&mut self) {
         self.sink = None;                  // Close...even if not open :-)
+    }
+    fn flush(&mut self) {
+        if let Some(sink) = &mut self.sink {
+            sink.flush().expect("Failed to flush output offline data sourcde");
+        }
     }
 }


### PR DESCRIPTION
*  Update version in Cargo.toml 0.3.0
*  Added flush to DataSink trait with default action as a No-op.
*  Implemented flush() in the offline data source to flush the output stream if one is open (No-op if not).